### PR TITLE
remove globus-connect-server node setup --client-id

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -57,7 +57,6 @@ echo $DEPLOYMENT_KEY > $deployment_key
 chmod 600 $deployment_key
 
 globus-connect-server node setup     \
-    --client-id $GLOBUS_CLIENT_ID    \
     --deployment-key $deployment_key \
     $NODE_SETUP_ARGS
 


### PR DESCRIPTION
This argument no longer supported or necessary in latest globus version. After running `globus-connect-server endpoint key convert` and saving the updated deployment key, this seems to all work without it.